### PR TITLE
fix(php): remove mbstring.internal_encoding

### DIFF
--- a/docker/backend/php.ini
+++ b/docker/backend/php.ini
@@ -9,5 +9,4 @@ post_max_size = 5M
 date.timezone = "Asia/Tokyo"
 
 [mbstring]
-mbstring.internal_encoding = "UTF-8"
 mbstring.language = "Japanese"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **変更点**
  - `php.ini` ファイルから `mbstring.internal_encoding` 設定を削除しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->