### PR TITLE
fix(phpstan): remove configuration option

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,4 +28,4 @@ db:
 
 .PHONY: phpstan
 phpstan:
-	docker compose exec backend bash -c 'vendor/bin/phpstan clear-result-cache && vendor/bin/phpstan analyse --configuration phpstan.neon'
+	docker compose exec backend bash -c 'vendor/bin/phpstan clear-result-cache && vendor/bin/phpstan analyse'

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -19,4 +19,4 @@ pre-commit:
     phpstan:
       root: backend
       glob: "*.php"
-      run: docker compose exec backend bash -c 'vendor/bin/phpstan clear-result-cache && vendor/bin/phpstan analyse --configuration phpstan.neon {staged_files}'
+      run: docker compose exec backend bash -c 'vendor/bin/phpstan clear-result-cache && vendor/bin/phpstan analyse {staged_files}'


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - `phpstan`実行時の`--configuration phpstan.neon`引数を削除しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->