### PR TITLE
chore: update markdownlint config

### DIFF
--- a/.markdownlint.yml
+++ b/.markdownlint.yml
@@ -2,5 +2,9 @@
 
 default: true
 
+MD013: false
+
 MD024:
   siblings_only: true
+
+MD029: false


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Chores
  * MarkdownLintの設定を更新し、MD013（行長）とMD029（番号付きリスト接頭辞）を無効化。ドキュメント執筆時の制約を緩和します。
  * MD024はsiblings_only: trueのまま維持し、同一階層での重複見出しのみを防止します。
  * 変更はMarkdownのリンティング挙動に限られ、アプリの機能、UI、API、実行時パフォーマンスには影響しません。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->