### PR TITLE
fix: restrict workflow permissions

### DIFF
--- a/.github/workflows/lint-docker.yml
+++ b/.github/workflows/lint-docker.yml
@@ -2,7 +2,8 @@ name: lint-docker
 on:
   pull_request:
     types: [opened, reopened, synchronize]
-permissions: write-all
+permissions:
+  contents: read
 jobs:
   hadolint:
     runs-on: ubuntu-latest

--- a/.github/workflows/preset-pr.yml
+++ b/.github/workflows/preset-pr.yml
@@ -6,7 +6,9 @@ run-name: ${{ github.workflow }} (${{ github.ref_name }})
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: false
-permissions: write-all
+permissions:
+  pull-requests: write
+  issues: write
 jobs:
   call-preset-pr:
     uses: jnicrimi/reusable-workflows/.github/workflows/called-preset-pr.yml@main


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * GitHub Actions の権限を最小化。lint-docker ワークフローはリポジトリ内容を読み取り専用に変更。
  * preset-pr ワークフローは一括の書き込み権限を廃止し、プルリクエスト/Issues のみ書き込み可に限定。
  * セキュリティと運用の安全性を向上。エンドユーザー向け機能や挙動の変更はありません。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->