### PR TITLE
chore: remove run-name from workflows

### DIFF
--- a/.github/workflows/lint-php.yml
+++ b/.github/workflows/lint-php.yml
@@ -2,7 +2,6 @@ name: lint-php
 on:
   pull_request:
     types: [opened, reopened, synchronize]
-run-name: ${{ github.workflow }} (${{ github.ref_name }})
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/lint-redoc.yml
+++ b/.github/workflows/lint-redoc.yml
@@ -2,7 +2,6 @@ name: lint-redoc
 on:
   pull_request:
     types: [opened, reopened, synchronize]
-run-name: ${{ github.workflow }} (${{ github.ref_name }})
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/preset-pr.yml
+++ b/.github/workflows/preset-pr.yml
@@ -2,7 +2,6 @@ name: preset-pr
 on:
   pull_request:
     types: [opened, reopened]
-run-name: ${{ github.workflow }} (${{ github.ref_name }})
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: false

--- a/.github/workflows/test-php.yml
+++ b/.github/workflows/test-php.yml
@@ -2,7 +2,6 @@ name: test-php
 on:
   pull_request:
     types: [opened, reopened, synchronize]
-run-name: ${{ github.workflow }} (${{ github.ref_name }})
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* チョア
  * CIワークフローの実行名の明示指定を削除し、デフォルト名に統一。実行履歴の表示を標準化し、設定の一貫性を向上。アプリの機能、UI、パフォーマンス、互換性への影響はありません。既存の検証やテストの内容・結果は従来どおりです。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->