### PR TITLE
ci: add concurrency to lint-docker workflow

### DIFF
--- a/.github/workflows/lint-docker.yml
+++ b/.github/workflows/lint-docker.yml
@@ -2,6 +2,9 @@ name: lint-docker
 on:
   pull_request:
     types: [opened, reopened, synchronize]
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 permissions:
   contents: read
 jobs:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- チョア
  - Lint ワークフローに同時実行制御を導入し、同一グループの並行実行を自動キャンセルして重複ジョブを抑制。
  - 不要な実行が減少し、CI の待ち時間短縮と通知の明瞭さが向上。
  - 安定したフィードバックサイクルにより開発体験が改善。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->